### PR TITLE
Allow warning 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
   },
   "dependencies": {
     "react-is": "^16.3.2",
-    "warning": "^3.0.0"
+    "warning": "^4.0.0"
   }
 }


### PR DESCRIPTION
The breaking changes are a license change and internals. Updating it shouldn't cause issues.